### PR TITLE
Adding oracle driver to the mix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # BlueJ files
 *.ctxt
 
+.idea/
+*.iml
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ The driver is named `postgresql`.
 This [layer](src/main/resources/layers/standalone/mysql-driver/layer-spec.xml) install mysql driver (for current version check in [pom.xml](pom.xml)) as JBOSS modules inside a WildFly server.
 The driver is named `mysql`.
 
+`oracle-10-driver` layer
+---------------------------------
+This [layer](src/main/resources/layers/standalone/oracle-10-driver/layer-spec.xml) install oracle driver (for current version check in [pom.xml](pom.xml)) as JBOSS modules inside a WildFly server.
+The driver is named `oracle-10`.
+
 `postgresql-datasource` layer
 ---------------------------------
 This [layer](src/main/resources/layers/standalone/postgresql-datasource/layer-spec.xml) creates a postgresql datasource.
@@ -52,4 +57,24 @@ The JNDI name of the datasource is: `java:jboss/datasources/${env.MYSQL_DATASOUR
 `mysql-default-datasource` layer
 ---------------------------------
 This [layer](src/main/resources/layers/standalone/mysql-default-datasource/layer-spec.xml) sets the mysql datasource as the 
+ee subsystem default datasource.
+
+`oracle-datasource` layer
+---------------------------------
+This [layer](src/main/resources/layers/standalone/oracle-datasource/layer-spec.xml) creates an oracle datasource.
+The datasource is named `OracleDS`. The datasource name may be changed at server execution with env variable:
+
+* `ORACLE_DATASOURCE`
+
+The JNDI name of the datasource is: `java:jboss/datasources/${env.ORACLE_DATASOURCE,env.OPENSHIFT_ORACLE_DATASOURCE:OracleDS}`
+
+JDBC connection properties can be configured at server execution time with the following env variables:
+
+* `ORACLE_URL`
+* `ORACLE_USER`
+* `ORACLE_PASSWORD`
+
+`oracle-default-datasource` layer
+---------------------------------
+This [layer](src/main/resources/layers/standalone/oracle-default-datasource/layer-spec.xml) sets the oracle datasource as the 
 ee subsystem default datasource.

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <version.org.wildfly>7.3.0.CD18-redhat-00002</version.org.wildfly>
         <version.org.wildfly.galleon-plugins>4.0.3.Final</version.org.wildfly.galleon-plugins>
         <version.org.postgresql.postgresql>42.2.8</version.org.postgresql.postgresql>
+        <version.com.oracle.ojdbc10>19.3.0.0</version.com.oracle.ojdbc10>
         <version.mysql.mysql-connector-java>8.0.18</version.mysql.mysql-connector-java>
         <wildfly-extras.repo.scm.connection>git@github.com:wildfly-extras/wildfly-datasources-galleon-pack.git</wildfly-extras.repo.scm.connection>
         <wildfly-extras.repo.scm.url>https://github.com/wildfly-extras/wildfly-datasources-galleon-pack</wildfly-extras.repo.scm.url>   
@@ -62,6 +63,11 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${version.org.postgresql.postgresql}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.ojdbc</groupId>
+            <artifactId>ojdbc10</artifactId>
+            <version>${version.com.oracle.ojdbc10}</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/src/main/resources/layers/standalone/oracle-10-driver/layer-spec.xml
+++ b/src/main/resources/layers/standalone/oracle-10-driver/layer-spec.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="oracle-10-driver">
+    <feature spec="subsystem.datasources">
+        <feature spec="subsystem.datasources.jdbc-driver">
+            <param name="driver-name" value="oracle-10"/>
+            <param name="jdbc-driver" value="oracle-10"/>
+            <param name="driver-xa-datasource-class-name" value="oracle.jdbc.xa.client.OracleXADataSource"/>
+            <param name="driver-module-name" value="com.oracle.ojdbc10"/>
+        </feature>
+    </feature>
+    <packages>
+        <package name="com.oracle.ojdbc10"/>
+    </packages>
+</layer-spec>
+

--- a/src/main/resources/layers/standalone/oracle-datasource/layer-spec.xml
+++ b/src/main/resources/layers/standalone/oracle-datasource/layer-spec.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="oracle-datasource">
+    <dependencies>
+        <layer name="oracle-10-driver"/>
+    </dependencies>
+
+    <feature spec="subsystem.datasources.data-source">
+        <param name="use-ccm" value="true"/>
+        <!-- we can't use expression for pool-name (data-source name) hard coding should be fine, the import thing is JNDI -->
+        <param name="data-source" value="OracleDS"/>
+        <param name="enabled" value="true"/>
+        <param name="use-java-context" value="true"/>
+        <param name="jndi-name" value="java:jboss/datasources/${env.ORACLE_DATASOURCE,env.OPENSHIFT_ORACLE_DATASOURCE:OracleDS}"/>
+        <param name="connection-url" value="${env.ORACLE_URL, env.OPENSHIFT_ORACLE_URL}"/>
+        <param name="driver-name" value="oracle-10"/>
+        <param name="user-name" value="${env.ORACLE_USER, env.OPENSHIFT_ORACLE_DB_USERNAME}"/>
+        <param name="password" value="${env.ORACLE_PASSWORD, env.OPENSHIFT_ORACLE_DB_PASSWORD}"/>
+        <param name="validate-on-match" value="true"/>
+        <param name="background-validation" value="false"/>
+        <param name="valid-connection-checker-class-name" value="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleValidConnectionChecker" />
+        <param name="stale-connection-checker-class-name" value="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleStaleConnectionChecker" />
+        <param name="exception-sorter-class-name" value="org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter" />
+        <param name="statistics-enabled" value="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}" />
+    </feature>
+</layer-spec>
+

--- a/src/main/resources/layers/standalone/oracle-default-datasource/layer-spec.xml
+++ b/src/main/resources/layers/standalone/oracle-default-datasource/layer-spec.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="oracle-default-datasource">
+    <dependencies>
+        <layer name="oracle-datasource"/>
+    </dependencies>
+
+    <feature spec="subsystem.ee.service.default-bindings">
+        <param name="datasource" value="java:jboss/datasources/${env.ORACLE_DATASOURCE,env.OPENSHIFT_ORACLE_DATASOURCE:OracleDS}"/>
+    </feature>
+</layer-spec>
+

--- a/src/main/resources/modules/com/oracle/ojdbc10/main/module.xml
+++ b/src/main/resources/modules/com/oracle/ojdbc10/main/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="com.oracle.ojdbc10" xmlns="urn:jboss:module:1.8">
+    <resources>
+        <artifact name="${com.oracle.ojdbc:ojdbc10}"/>
+    </resources>
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="javax.transaction.api"/>
+    </dependencies>
+</module>
+


### PR DESCRIPTION
@jfdenise per your comment at https://github.com/jboss-container-images/jboss-eap-modules/pull/166 I'm opening this PR.

It's not finished and I want to use this as possibility to check with you what is expected to be part of the PR.
* the oracle driver part works
* the oracle datasource part does not work - as first I'm not sure how to define the classes for `valid-connection-checker/stale-connection-checker/exception-sorter`. Where I can find the repository of galleon datasource layers to check what are the options?
* the oracle datasource part uses the `connection-url` to be created from `host/port/dbname`. But I wonder if that scheme is expected or a env variable for url could be used? I think it's better fit to use url for Oracle than to build the url from other values.
* should be created two PR? One for `eap` branch and the other for `master`(wildfly)?