### PR TITLE
Use oracle8, JDK8 compatible. Make names unrelated to driver version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ The driver is named `postgresql`.
 This [layer](src/main/resources/layers/standalone/mysql-driver/layer-spec.xml) install mysql driver (for current version check in [pom.xml](pom.xml)) as JBOSS modules inside a WildFly server.
 The driver is named `mysql`.
 
-`oracle-10-driver` layer
+`oracle-driver` layer
 ---------------------------------
-This [layer](src/main/resources/layers/standalone/oracle-10-driver/layer-spec.xml) install oracle driver (for current version check in [pom.xml](pom.xml)) as JBOSS modules inside a WildFly server.
-The driver is named `oracle-10`.
+This [layer](src/main/resources/layers/standalone/oracle-driver/layer-spec.xml) install oracle driver (for current version check in [pom.xml](pom.xml)) as JBOSS modules inside a WildFly server.
+The driver is named `oracle`.
 
 `postgresql-datasource` layer
 ---------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <version.org.wildfly>18.0.0.Final</version.org.wildfly>
         <version.org.wildfly.galleon-plugins>4.0.3.Final</version.org.wildfly.galleon-plugins>
         <version.org.postgresql.postgresql>42.2.8</version.org.postgresql.postgresql>
-        <version.com.oracle.ojdbc10>19.3.0.0</version.com.oracle.ojdbc10>
+        <version.com.oracle.ojdbc8>19.3.0.0</version.com.oracle.ojdbc8>
         <version.mysql.mysql-connector-java>8.0.18</version.mysql.mysql-connector-java>
         <wildfly-extras.repo.scm.connection>git@github.com:wildfly-extras/wildfly-datasources-galleon-pack.git</wildfly-extras.repo.scm.connection>
         <wildfly-extras.repo.scm.url>https://github.com/wildfly-extras/wildfly-datasources-galleon-pack</wildfly-extras.repo.scm.url>   
@@ -65,8 +65,8 @@
         </dependency>
         <dependency>
             <groupId>com.oracle.ojdbc</groupId>
-            <artifactId>ojdbc10</artifactId>
-            <version>${version.com.oracle.ojdbc10}</version>
+            <artifactId>ojdbc8</artifactId>
+            <version>${version.com.oracle.ojdbc8}</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/src/main/resources/layers/standalone/oracle-datasource/layer-spec.xml
+++ b/src/main/resources/layers/standalone/oracle-datasource/layer-spec.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="oracle-datasource">
     <dependencies>
-        <layer name="oracle-10-driver"/>
+        <layer name="oracle-driver"/>
     </dependencies>
 
     <feature spec="subsystem.datasources.data-source">
@@ -12,7 +12,7 @@
         <param name="use-java-context" value="true"/>
         <param name="jndi-name" value="java:jboss/datasources/${env.ORACLE_DATASOURCE,env.OPENSHIFT_ORACLE_DATASOURCE:OracleDS}"/>
         <param name="connection-url" value="${env.ORACLE_URL, env.OPENSHIFT_ORACLE_URL}"/>
-        <param name="driver-name" value="oracle-10"/>
+        <param name="driver-name" value="oracle"/>
         <param name="user-name" value="${env.ORACLE_USER, env.OPENSHIFT_ORACLE_DB_USERNAME}"/>
         <param name="password" value="${env.ORACLE_PASSWORD, env.OPENSHIFT_ORACLE_DB_PASSWORD}"/>
         <param name="validate-on-match" value="true"/>

--- a/src/main/resources/layers/standalone/oracle-driver/layer-spec.xml
+++ b/src/main/resources/layers/standalone/oracle-driver/layer-spec.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="oracle-10-driver">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="oracle-driver">
     <feature spec="subsystem.datasources">
         <feature spec="subsystem.datasources.jdbc-driver">
-            <param name="driver-name" value="oracle-10"/>
-            <param name="jdbc-driver" value="oracle-10"/>
+            <param name="driver-name" value="oracle"/>
+            <param name="jdbc-driver" value="oracle"/>
             <param name="driver-xa-datasource-class-name" value="oracle.jdbc.xa.client.OracleXADataSource"/>
-            <param name="driver-module-name" value="com.oracle.ojdbc10"/>
+            <param name="driver-module-name" value="com.oracle.ojdbc"/>
         </feature>
     </feature>
     <packages>
-        <package name="com.oracle.ojdbc10"/>
+        <package name="com.oracle.ojdbc"/>
     </packages>
 </layer-spec>
 

--- a/src/main/resources/modules/com/oracle/ojdbc/main/module.xml
+++ b/src/main/resources/modules/com/oracle/ojdbc/main/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module name="com.oracle.ojdbc10" xmlns="urn:jboss:module:1.8">
+<module name="com.oracle.ojdbc" xmlns="urn:jboss:module:1.8">
     <resources>
-        <artifact name="${com.oracle.ojdbc:ojdbc10}"/>
+        <artifact name="${com.oracle.ojdbc:ojdbc8}"/>
     </resources>
     <dependencies>
         <module name="javax.api"/>


### PR DESCRIPTION
ojdbc10 driver is JDK11 only. both 8 and 10 supports 19.3 DB version.