### PR TITLE
Fix for Issue #203, MariaDB driver needs to be dependent on slf4j

### DIFF
--- a/common/src/main/resources/modules/org/mariadb/jdbc/main/module.xml
+++ b/common/src/main/resources/modules/org/mariadb/jdbc/main/module.xml
@@ -8,6 +8,7 @@
         <module name="sun.jdk"/>
         <module name="ibm.jdk"/>
         <module name="javax.api"/>
+        <module name="org.slf4j"/>
     </dependencies>
 </module>
 


### PR DESCRIPTION
@bstansberry , the slf4j dependency added to the mariadb module.