### PR TITLE
Support for PostgreSQL XA datasource

### DIFF
--- a/common/src/main/resources/layers/standalone/postgresql-default-xa-datasource/layer-spec.xml
+++ b/common/src/main/resources/layers/standalone/postgresql-default-xa-datasource/layer-spec.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="postgresql-default-xa-datasource">
+    <props>
+        <prop name="org.wildfly.rule.add-on" value="database,postgresql:default"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Documentation in https://github.com/wildfly-extras/wildfly-datasources-galleon-pack"/>
+        <prop name="org.wildfly.rule.add-on-fix-no-default-datasource" value=""/>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-datasources-galleon-pack/main/doc/postgresql/env.yaml"/>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="only:datasources"/>
+    </props>
+    <dependencies>
+        <layer name="datasources"/>
+        <layer name="postgresql-datasource"/>
+    </dependencies>
+    
+    <feature spec="subsystem.ee.service.default-bindings">
+        <param name="datasource" value="${org.wildfly.datasources.postgresql.jndi-name,env.POSTGRESQL_JNDI:java:jboss/datasources/${org.wildfly.datasources.postgresql.datasource, env.POSTGRESQL_DATASOURCE,env.OPENSHIFT_POSTGRESQL_DATASOURCE:PostgreSQLXADS}}"/>
+    </feature>
+</layer-spec>
+

--- a/common/src/main/resources/layers/standalone/postgresql-xa-datasource/layer-spec.xml
+++ b/common/src/main/resources/layers/standalone/postgresql-xa-datasource/layer-spec.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="postgresql-xa-datasource">
+    <props>
+        <prop name="org.wildfly.rule.configuration" value="https://raw.githubusercontent.com/wildfly-extras/wildfly-datasources-galleon-pack/main/doc/postgresql/env.yaml"/>
+        <prop name="org.wildfly.rule.add-on" value="database,postgresql"/>
+        <prop name="org.wildfly.rule.add-on-description" value="Documentation in https://github.com/wildfly-extras/wildfly-datasources-galleon-pack"/>
+        <prop name="org.wildfly.rule.add-on-fix-unbound-datasources" value="JNDI env,POSTGRESQL_JNDI=##ITEM##"/>
+        <prop name="org.wildfly.rule.add-on-depends-on" value="only:datasources"/>
+    </props>
+    <dependencies>
+        <layer name="datasources"/>
+        <layer name="postgresql-driver"/>
+    </dependencies>
+    
+    <feature spec="subsystem.datasources.xa-data-source">
+        <!-- we can't use expression for pool-name (xa-data-source name) hard coding should be fine, the important thing is JNDI -->
+        <param name="xa-data-source" value="PostgreSQLXADS"/>
+        <param name="enabled" value="${org.wildfly.datasources.postgresql.enabled, env.POSTGRESQL_ENABLED:true}"/>
+        <param name="exception-sorter-class-name" value="${org.wildfly.datasources.postgresql.exception-sorter-class-name, env.POSTGRESQL_EXCEPTION_SORTER:org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter}"/>
+        <param name="idle-timeout-minutes" value="${org.wildfly.datasources.postgresql.idle-timeout-minutes,env.POSTGRESQL_IDLE_TIMEOUT_MINUTES:30}"/>
+        <param name="jndi-name" value="${org.wildfly.datasources.postgresql.jndi-name,env.POSTGRESQL_JNDI:java:jboss/datasources/${org.wildfly.datasources.postgresql.datasource, env.POSTGRESQL_DATASOURCE,env.OPENSHIFT_POSTGRESQL_DATASOURCE:PostgreSQLXADS}}"/>
+        <param name="jta" value="${org.wildfly.datasources.postgresql.jta,env.POSTGRESQL_JTA:true}"/>
+        <param name="max-pool-size" value="${org.wildfly.datasources.postgresql.max-pool-size,env.POSTGRESQL_MAX_POOL_SIZE:20}"/>
+        <param name="min-pool-size" value="${org.wildfly.datasources.postgresql.min-pool-size,env.POSTGRESQL_MIN_POOL_SIZE:0}"/>
+        <param name="connection-url" value="${org.wildfly.datasources.postgresql.connection-url,env.POSTGRESQL_URL:jdbc:postgresql://${org.wildfly.datasources.postgresql.host,env.POSTGRESQL_SERVICE_HOST,env.OPENSHIFT_POSTGRESQL_DB_HOST,env.POSTGRESQL_HOST:localhost}:${org.wildfly.datasources.postgresql.port,env.POSTGRESQL_SERVICE_PORT,env.OPENSHIFT_POSTGRESQL_DB_PORT,env.POSTGRESQL_PORT:5432}/${org.wildfly.datasources.postgresql.database,env.POSTGRESQL_DATABASE,env.OPENSHIFT_POSTGRESQL_DB_NAME}}"/>
+        <param name="driver-name" value="postgresql"/>
+        <param name="user-name" value="${org.wildfly.datasources.postgresql.user-name,env.POSTGRESQL_USER,env.OPENSHIFT_POSTGRESQL_DB_USERNAME}"/>
+        <param name="password" value="${org.wildfly.datasources.postgresql.password,env.POSTGRESQL_PASSWORD,env.OPENSHIFT_POSTGRESQL_DB_PASSWORD}"/>
+        <param name="validate-on-match" value="${org.wildfly.datasources.postgresql.validate-on-match,env.POSTGRESQL_VALIDATE_ON_MATCH:true}"/>
+        <param name="background-validation" value="${org.wildfly.datasources.postgresql.background-validation,env.POSTGRESQL_BACKGROUND_VALIDATION:false}"/>
+        <param name="background-validation-millis" value="${org.wildfly.datasources.postgresql.background-validation-millis,env.POSTGRESQL_BACKGROUND_VALIDATION_MILLIS:10000}"/>
+        <param name="flush-strategy" value="${org.wildfly.datasources.postgresql.flush-strategy,env.POSTGRESQL_FLUSH_STRATEGY:FailingConnectionOnly}"/>
+        <param name="statistics-enabled" value="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}" />
+        <param name="stale-connection-checker-class-name" value="${org.wildfly.datasources.postgresql.stale-connection-checker-class-name,env.POSTGRESQL_STALE_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.novendor.NullStaleConnectionChecker}" />
+        <param name="valid-connection-checker-class-name" value="${org.wildfly.datasources.postgresql.valid-connection-checker-class-name,env.POSTGRESQL_CONNECTION_CHECKER:org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker}"/>
+        <param name="transaction-isolation" value="${org.wildfly.datasources.postgresql.transaction-isolation,env.POSTGRESQL_TX_ISOLATION:TRANSACTION_READ_COMMITTED}"/>
+        <param name="blocking-timeout-wait-millis" value="${org.wildfly.datasources.postgresql.blocking-timeout-wait-millis,env.POSTGRESQL_BLOCKING_TIMEOUT_WAIT_MILLIS:1000}"/>
+        <param name="allocation-retry" value="${org.wildfly.datasources.postgresql.allocation-retry,env.POSTGRESQL_ALLOCATION_RETRY:5}"/>
+        <param name="allocation-retry-wait-millis" value="${org.wildfly.datasources.postgresql.allocation-retry-wait-millis,env.POSTGRESQL_ALLOCATION_RETRY_WAIT_MILLIS:200}"/>
+        <param name="xa-resource-timeout" value="${org.wildfly.datasources.postgresql.xa-resource-timeout,env.POSTGRESQL_XA_RESOURCE_TIMEOUT:60}"/>
+        <param name="xa-datasource-class" value="${org.wildfly.datasources.postgresql.xa-datasource-class,env.POSTGRESQL_XA_DATASOURCE_CLASS:org.postgresql.xa.PGXADataSource}"/>
+    </feature>
+</layer-spec>
+

--- a/doc/postgresql/README.md
+++ b/doc/postgresql/README.md
@@ -148,3 +148,32 @@ Optional configuration
   * Default Value: `true`
   * System Property: `org.wildfly.datasources.postgresql.validate-on-match`
 
+* `POSTGRESQL_BLOCKING_TIMEOUT_WAIT_MILLIS`
+
+  * Description: Specifies the maximum time, in milliseconds, that a connection factory will block waiting for a connection to be available.
+  * Default Value: `1000`
+  * System Property: `org.wildfly.datasources.postgresql.blocking-timeout-wait-millis`
+
+* `POSTGRESQL_ALLOCATION_RETRY`
+
+  * Description: Specifies the number of times to retry allocation of a connection before failing.
+  * Default Value: `5`
+  * System Property: `org.wildfly.datasources.postgresql.allocation-retry`
+
+* `POSTGRESQL_ALLOCATION_RETRY_WAIT_MILLIS`
+
+  * Description: Specifies the time, in milliseconds, to wait between allocation retries.
+  * Default Value: `200`
+  * System Property: `org.wildfly.datasources.postgresql.allocation-retry-wait-millis`
+
+* `POSTGRESQL_XA_RESOURCE_TIMEOUT`
+
+  * Description: Specifies the timeout, in seconds, for the XA resource.
+  * Default Value: `60`
+  * System Property: `org.wildfly.datasources.postgresql.xa-resource-timeout`
+
+* `POSTGRESQL_XA_DATASOURCE_CLASS`
+
+    * Description: Specifies the XA datasource class name.
+    * Default Value: `org.postgresql.xa.PGXADataSource`
+    * System Property: `org.wildfly.datasources.postgresql.xa-datasource-class`

--- a/doc/postgresql/env.yaml
+++ b/doc/postgresql/env.yaml
@@ -10,38 +10,48 @@ envs:
     - name: POSTGRESQL_USER
       description: "Defines the username for the datasource."
       required: true
-    - name: POSTGRESQL_BACKGROUND_VALIDATION"
+    - name: POSTGRESQL_BACKGROUND_VALIDATION
       description: "When set to true database connections are validated periodically in a background thread prior to use. Defaults to false, meaning the `validate-on-match` method is enabled by default instead."
-    - name: "POSTGRESQL_BACKGROUND_VALIDATION_MILLIS"
+    - name: POSTGRESQL_BACKGROUND_VALIDATION_MILLIS
       description: "Specifies frequency of the validation, in milliseconds, when the `background-validation` database connection validation mechanism is enabled. Default Value: `10000`"
-    - name: "POSTGRESQL_CONNECTION_CHECKER"
+    - name: POSTGRESQL_CONNECTION_CHECKER
       description: "Specifies a connection checker class that is used to validate connections. Valid value: `org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker`."
-    - name: "POSTGRESQL_DATASOURCE"
+    - name: POSTGRESQL_DATASOURCE
       description: "Datasource name used in the `jndi-name`. Default Value: `PostgreSQLDS`"
-    - name: "POSTGRESQL_ENABLED"
+    - name: POSTGRESQL_ENABLED
       description: "Set to false to disable the datasource."
-    - name: "POSTGRESQL_EXCEPTION_SORTER"
+    - name: POSTGRESQL_EXCEPTION_SORTER
       description: "Specifies the exception sorter class that is used to properly detect and clean up after fatal database connection exceptions. Valid value: `org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter`."
-    - name: "POSTGRESQL_FLUSH_STRATEGY"
+    - name: POSTGRESQL_FLUSH_STRATEGY
       description: "Specifies how the datasource should be flushed in case of an error. Default Value: `FailingConnectionOnly`"
-    - name: "POSTGRESQL_HOST"
+    - name: POSTGRESQL_HOST
       description: "Defines the database server’s host name or IP address to be used in the datasource’s `connection-url` property. Default Value: `localhost`"
-    - name: "POSTGRESQL_IDLE_TIMEOUT_MINUTES"
+    - name: POSTGRESQL_IDLE_TIMEOUT_MINUTES
       description: "Specifies the maximum time, in minutes, a connection may be idle before being closed. Default Value:`30`"
-    - name: "POSTGRESQL_JNDI"
+    - name: POSTGRESQL_JNDI
       description: "Defines the JNDI name for the datasource. Default Value: `java:jboss/datasources/${POSTGRESQL_DATASOURCE}`"
-    - name: "POSTGRESQL_JTA"
+    - name: POSTGRESQL_JTA
       description: "Defines Java Transaction API (JTA) option for the non-XA datasource."
-    - name: "POSTGRESQL_MAX_POOL_SIZE"
+    - name: POSTGRESQL_MAX_POOL_SIZE
       description: "Defines the maximum pool size option for the datasource. Default Value: `20`"
-    - name: "POSTGRESQL_MIN_POOL_SIZE"
+    - name: POSTGRESQL_MIN_POOL_SIZE
       description: "Defines the minimum pool size option for the datasource. Default Value: `0`"
-    - name: "POSTGRESQL_PORT"
+    - name: POSTGRESQL_PORT
       description: "Defines the database server’s port to be used in the datasource’s `connection-url` property. Default Value: `5432`"
-    - name: "POSTGRESQL_STALE_CONNECTION_CHECKER"
+    - name: POSTGRESQL_STALE_CONNECTION_CHECKER
       description: "Specifies a connection checker class that is used to check stale connections. Valid value: `org.jboss.jca.adapters.jdbc.extensions.postgres.StaleConnectionChecker."
-    - name: "POSTGRESQL_TX_ISOLATION"
+    - name: POSTGRESQL_TX_ISOLATION
       description: "Defines the `java.sql.Connection` transaction isolation level for the datasource. Default Value: `TRANSACTION_READ_COMMITTED`"
-    - name: "POSTGRESQL_VALIDATE_ON_MATCH"
+    - name: POSTGRESQL_VALIDATE_ON_MATCH
       description: "Indicates whether or not connection level validation should be done when a connection factory attempts to match a managed connection for a given set. This is typically exclusive to the use of background validation."
+    - name: POSTGRESQL_BLOCKING_TIMEOUT_WAIT_MILLIS
+      description: "Specifies the maximum time, in milliseconds, that a connection factory will block waiting for a connection to be available. Default Value: `1000`"
+    - name: POSTGRESQL_ALLOCATION_RETRY
+      description: "Specifies the number of times to retry allocation of a connection before failing. Default Value: `5`"
+    - name: POSTGRESQL_ALLOCATION_RETRY_WAIT_MILLIS
+      description: "Specifies the time, in milliseconds, to wait between allocation retries. Default Value: `200`"
+    - name: POSTGRESQL_XA_RESOURCE_TIMEOUT
+      description: "Specifies the timeout, in seconds, for XA resources. Default Value: `60`"
+    - name: POSTGRESQL_XA_DATASOURCE_CLASS
+      description: "Specifies the XA datasource class. Default Value: `org.postgresql.xa.PGXADataSource`"
 


### PR DESCRIPTION
I added the following layers:
 - postgresql-xa-datasource
 - postgresql-default-xa-datasource

Updated `doc/postgresql/env.yaml` and `doc/postgresql/README.md` with couple of new environment variables:
- POSTGRESQL_BLOCKING_TIMEOUT_WAIT_MILLIS
- POSTGRESQL_ALLOCATION_RETRY
- POSTGRESQL_ALLOCATION_RETRY_WAIT_MILLIS
- POSTGRESQL_XA_RESOURCE_TIMEOUT
- POSTGRESQL_XA_DATASOURCE_CLASS

Let me know what else is required.