### PR TITLE
Support AWS JDBC Wrapper for PostgreSQL, MySQL and MariaDB

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -64,6 +64,10 @@
             <groupId>com.ibm.db2</groupId>
             <artifactId>jcc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.jdbc</groupId>
+            <artifactId>aws-advanced-jdbc-wrapper</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/common/src/main/resources/layers/standalone/awswrapper-driver/layer-spec.xml
+++ b/common/src/main/resources/layers/standalone/awswrapper-driver/layer-spec.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="awswrapper-driver">
+    <props>
+        <prop name="org.wildfly.category" value="Database"/>
+        <prop name="org.wildfly.rule.xml-path" value="[/META-INF/*.xml,/WEB-INF/*.xml],/datasources/datasource/driver,aws-wrapper"/>
+        <prop name="org.wildfly.rule.annotation.field.value-className" value="jakarta.annotation.sql.DataSourceDefinition,className=software.amazon.jdbc.*"/>
+    </props>
+    <dependencies>
+        <layer name="datasources"/>
+    </dependencies>
+    <feature spec="subsystem.datasources">
+        <feature spec="subsystem.datasources.jdbc-driver">
+            <param name="jdbc-driver" value="aws-wrapper"/>
+            <param name="driver-class-name" value="software.amazon.jdbc.Driver"/>
+            <param name="driver-module-name" value="software.amazon.jdbc"/>
+        </feature>
+    </feature>
+    <packages>
+        <package name="software.amazon.jdbc"/>
+    </packages>
+</layer-spec>
+

--- a/common/src/main/resources/modules/software/amazon/jdbc/main/module.xml
+++ b/common/src/main/resources/modules/software/amazon/jdbc/main/module.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="software.amazon.jdbc" xmlns="urn:jboss:module:1.8">
+    <resources>
+        <artifact name="${software.amazon.jdbc:aws-advanced-jdbc-wrapper}"/>
+    </resources>
+    <dependencies>
+        <module name="org.postgresql.jdbc" services="import" optional="true"/>
+        <module name="com.mysql.jdbc" services="import" optional="true"/>
+        <module name="org.mariadb.jdbc" services="import" optional="true"/>
+        <module name="wildflyee.api"/>
+        <module name="jdk.net"/>
+        <module name="jdk.security.jgss"/>
+    </dependencies>
+</module>

--- a/doc/awswrapper/README.md
+++ b/doc/awswrapper/README.md
@@ -1,0 +1,50 @@
+Galleon Layers
+=========
+
+* `awswrapper-driver`: Provision the `aws-wrapper` driver. This layer installs the JBoss Modules module `software.amazon.jdbc`.
+
+Configuration
+========
+
+See https://github.com/aws/aws-advanced-jdbc-wrapper.
+
+The following set of environment variables and corresponding Java system properties can be used to configure the datasource.
+
+Using plugins (https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md#list-of-available-plugins) that require additional dependencies is currently not supported.
+
+* AWS Advanced JDBC Wrapper configuration parameters can be supplied in two ways:
+    * As part of the JDBC URL: `jdbc:aws-wrapper:postgresql://${POSTGRESQL_HOST}:${POSTGRESQL_PORT}/${POSTGRESQL_DATABASE}?wrapperLoggerLevel=DEBUG`
+    * Or as connection-properties in the underlying datasource: `/subsystem=datasources/data-source=PostgreSQLDS/connection-properties=wrapperLoggerLevel:add(value=DEBUG)`
+
+Required configuration
+==============
+
+The AWS Advanced JDBC Wrapper module imports all supported native JDBC datasources.
+
+* Datasource: Users must explicitly include the desired native datasource layer
+    * `postgresql-datasource`
+    * `mysql-datasource`
+    * `mariadb-datasource`
+
+
+* Wrapper Protocol: The AWS Advanced JDBC Wrapper uses the protocol prefix `jdbc:aws-wrapper:`
+    * When using PostgreSQL, the `POSTGRESQL_URL` must be set to include the `aws-wrapper` as driver name:`jdbc:aws-wrapper:postgresql://${POSTGRESQL_HOST}:${POSTGRESQL_PORT}/${POSTGRESQL_DATABASE}`
+    * When using MySQL, the `MYSQL_URL` must be set to include the `aws-wrapper` as driver name:`jdbc:aws-wrapper:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}`
+    * When using MariaDB, the `MARIADB_URL` must be set to include the `aws-wrapper` as driver name:`jdbc:aws-wrapper:mariadb://${MARIADB_HOST}:${MARIADB_PORT}/${MARIADB_DATABASE}`
+
+
+* Driver: Bind the AWS Advanced JDBC Wrapper driver to the underlying datasource by overriding the `driver-name` parameter
+    * `/subsystem=datasources/data-source=PostgreSQLDS:write-attribute(name=driver-name,value=aws-wrapper)`
+
+
+* `clusterId`: wrapper configuration parameter, used to identify connections to different database clusters
+    * If connecting to multiple database clusters, this parameter is required
+    * Otherwise, it is optional
+    * `/subsystem=datasources/data-source=PostgreSQLDS/connection-properties=clusterId:add(value=123)`
+    * For detailed information, see https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/ClusterId.md
+
+Optional configuration
+==============
+
+* See https://github.com/aws/aws-advanced-jdbc-wrapper
+* and https://github.com/aws/aws-advanced-jdbc-wrapper/blob/main/docs/using-the-jdbc-driver/UsingTheJdbcDriver.md#aws-advanced-jdbc-wrapper-parameters

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         <version.org.postgresql.postgresql>42.7.9</version.org.postgresql.postgresql>
+        <version.software.amazon.jdbc.aws-advanced-jdbc-wrapper>4.0.0</version.software.amazon.jdbc.aws-advanced-jdbc-wrapper>
         <version.com.h2database>2.4.240</version.com.h2database>
         <version.com.ibm.db2>12.1.3.0</version.com.ibm.db2>
         <version.com.microsoft.sqlserver>13.2.1.jre11</version.com.microsoft.sqlserver>
@@ -133,6 +134,11 @@
                 <groupId>com.ibm.db2</groupId>
                 <artifactId>jcc</artifactId>
                 <version>${version.com.ibm.db2}</version>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.jdbc</groupId>
+                <artifactId>aws-advanced-jdbc-wrapper</artifactId>
+                <version>${version.software.amazon.jdbc.aws-advanced-jdbc-wrapper}</version>
             </dependency>
             <!-- tests -->
             <dependency>

--- a/testsuite/layers-metadata-unit-tests/src/test/java/org/wildfly/datasources/galleon/pack/test/layers/metadata/AbstractLayerMetaDataTestCase.java
+++ b/testsuite/layers-metadata-unit-tests/src/test/java/org/wildfly/datasources/galleon/pack/test/layers/metadata/AbstractLayerMetaDataTestCase.java
@@ -41,7 +41,8 @@ public class AbstractLayerMetaDataTestCase {
             "mysql-driver",
             "oracle-driver",
             "postgresql-driver",
-            "db2-driver"
+            "db2-driver",
+            "awswrapper-driver"
     });
 
     @BeforeClass

--- a/testsuite/layers-metadata-unit-tests/src/test/java/org/wildfly/datasources/galleon/pack/test/layers/metadata/AwswrapperLayerMetaDataTestCase.java
+++ b/testsuite/layers-metadata-unit-tests/src/test/java/org/wildfly/datasources/galleon/pack/test/layers/metadata/AwswrapperLayerMetaDataTestCase.java
@@ -1,0 +1,27 @@
+package org.wildfly.datasources.galleon.pack.test.layers.metadata;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+public class AwswrapperLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
+    private static Path nonXaWar;
+    private static Path nonXaJar;
+
+    @BeforeClass
+    public static void createArchives() {
+        nonXaWar = createWebArchive("non-xa.war", "test-ds.xml", createDatasourceXml(false, "aws-wrapper"));
+        nonXaJar = createJavaArchive("non-xa.jar", "test-ds.xml", createDatasourceXml(false, "aws-wrapper"));
+    }
+
+    @Test
+    public void testNonXaWar() throws Exception {
+        checkLayersForArchive(nonXaWar, "awswrapper-driver");
+    }
+
+    @Test
+    public void testNonXaJar() throws Exception {
+        checkLayersForArchive(nonXaJar, "awswrapper-driver");
+    }
+}


### PR DESCRIPTION
This implements #423 

I have added a new driver-layer **awswrapper-driver** to support the [aws advanced jdbc wrapper](https://github.com/aws/aws-advanced-jdbc-wrapper).

The driver module imports all jdbc drivers that are supported by the wrapper:
- PostgreSQL / org.postgresql.jdbc
- MySQL / com.mysql.jdbc
- MariaDB / org.mariadb.jdbc